### PR TITLE
🔔 Adding registration success banner and redirect to homepage

### DIFF
--- a/client/packages/components/src/containers/Home.tsx
+++ b/client/packages/components/src/containers/Home.tsx
@@ -6,17 +6,24 @@ import { CreateClassDialog } from '../ui/CreateClassDialog'
 import { useService } from '../providers/ServiceProvider'
 import { createClassroomActions } from '../actions/classroom'
 import { useClassrooms } from '../providers/ClassroomsProvider'
+import { Alert } from '@material-ui/lab'
+import { useLocation } from 'react-router-dom'
 
 const useStyles = makeStyles((theme: Theme) => ({
   fab: {
     position: 'fixed',
     bottom: theme.spacing(2),
     right: theme.spacing(2)
+  },
+  alert: {
+    marginBottom: theme.spacing(2)
   }
 }))
 
 export const Classes = () => {
   const classes = useStyles()
+  // Adding any cast here because for some reason this is coming back as Location<unknown>
+  const location = useLocation() as any
   const [service] = useService()
   const [{ classrooms }, dispatch] = useClassrooms()
   const [open, setOpen] = useState(false)
@@ -40,7 +47,11 @@ export const Classes = () => {
           handleClose()
         }}
       />
-
+      {location?.state?.registrationSuccess && (
+        <Alert variant='outlined' severity={'success'} className={classes.alert}>
+          Registration successful!
+        </Alert>
+      )}
       <Typography variant='h4' gutterBottom>
         My Classes
       </Typography>

--- a/client/packages/components/src/containers/Home.tsx
+++ b/client/packages/components/src/containers/Home.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import { Add as AddIcon } from '@material-ui/icons'
 import { Fab, Grid, makeStyles, Theme, Typography } from '@material-ui/core'
+import { Alert } from '@material-ui/lab'
+import { useLocation } from 'react-router-dom'
 import { ClassCard } from '../ui/ClassCard'
 import { CreateClassDialog } from '../ui/CreateClassDialog'
 import { useService } from '../providers/ServiceProvider'
 import { createClassroomActions } from '../actions/classroom'
 import { useClassrooms } from '../providers/ClassroomsProvider'
-import { Alert } from '@material-ui/lab'
-import { useLocation } from 'react-router-dom'
 
 const useStyles = makeStyles((theme: Theme) => ({
   fab: {
@@ -47,11 +47,13 @@ export const Classes = () => {
           handleClose()
         }}
       />
-      {location?.state?.registrationSuccess && (
+
+      {location.state?.registrationSuccess && (
         <Alert variant='outlined' severity={'success'} className={classes.alert}>
           Registration successful!
         </Alert>
       )}
+
       <Typography variant='h4' gutterBottom>
         My Classes
       </Typography>

--- a/client/packages/components/src/index.tsx
+++ b/client/packages/components/src/index.tsx
@@ -28,7 +28,7 @@ const Routes = (i18nProps: WithTranslateProps) => {
       </Route>
 
       <Route path='/register'>
-        <Register {...i18nProps} />
+        {authState.token ? <Redirect to={{ pathname: '/home', state: { registrationSuccess: true } }} /> : <Register {...i18nProps} />}
       </Route>
 
       <Route path='/home'>


### PR DESCRIPTION
This PR addresses Issue #41

After going through the flow a few times, I realized there was a bit of a UX issue. On successful registration you stay on the registration page even though you can start navigating to other sections of the app, such as the homepage.

For this I decided to add a redirect to the homepage after a successful registration. Only at this time will a banner appear that says the registration was successful. Going to the homepage after this will not show that banner.

I know this was a bit off from what the ask was, but I think it makes a lot more sense! I attached a screenshot below of the new banner on the homepage:

![Screen Shot 2020-10-15 at 7 20 06 AM](https://user-images.githubusercontent.com/13204620/96143636-2146ee00-0eb8-11eb-863e-1b2e94beb94e.png) 